### PR TITLE
HTTPS en recursos del checkout

### DIFF
--- a/view/frontend/web/template/payment/openpay-offline.html
+++ b/view/frontend/web/template/payment/openpay-offline.html
@@ -24,22 +24,22 @@
         
         <div class="items check payable">            
             <h3 style="border-bottom: 1px solid #cccccc; padding-bottom: 15px;">Pago con transferencia electrónica (SPEI)</h3>            
-            <img src="http://s11.postimg.org/c5lz146pv/spei.png" alt="" style="max-width: 100%;" />
+            <img src="https://s11.postimg.org/c5lz146pv/spei.png" alt="" style="max-width: 100%;" />
             <p>
                 <a href="http://www.openpay.mx/bancos.html" target="_blank">Consulta los bancos soportados</a>
             </p>           
             <h4 style="margin-top: 25px; margin-bottom: 15px;">Pasos para tu pago por transferencia interbancaria</h4>
             <div style="overflow: hidden;">                
                 <div style="width: 30%; float: left; text-align: center; padding-left: 1.5%; padding-right: 1.5%;">
-                    <img src="http://s14.postimg.org/wt10fdulp/step1.png" alt="" style="max-width: 100%;" />
+                    <img src="https://s14.postimg.org/wt10fdulp/step1.png" alt="" style="max-width: 100%;" />
                     <p style="padding: 3px;">Haz clic en el botón "Generar CLABE", donde tu compra quedará en espera de que realices tu pago.</p>
                 </div>    
                 <div style="width: 30%; float: left; text-align: center; padding-left: 1.5%; padding-right: 1.5%;">
-                    <img src="http://s15.postimg.org/di3j47uxj/step_spei.png" alt="" style="max-width: 100%;" />
+                    <img src="https://s15.postimg.org/di3j47uxj/step_spei.png" alt="" style="max-width: 100%;" />
                     <p style="padding: 3px;">Sigue la guía para realizar el pago SPEI a través del portal de tu banco.</p>
                 </div>    
                 <div style="width: 30%; float: left; text-align: center; padding-left: 1.5%; padding-right: 1.5%;">
-                    <img src="http://s13.postimg.org/6c2yov3g3/step3.png" alt="" style="max-width: 100%;" />
+                    <img src="https://s13.postimg.org/6c2yov3g3/step3.png" alt="" style="max-width: 100%;" />
                     <p style="padding: 3px;">Inmediatamente después de recibir tu pago te enviaremos un correo electrónico con la confirmación de pago.</p>
                 </div>    
             </div>


### PR DESCRIPTION
Es indispensable usar HTTPS en checkout para evitar advertencias de certificado