### PR TITLE
Fix para guardar correctamente la dirección del cliente para Colombia.

### DIFF
--- a/Controller/Index/Webhook.php
+++ b/Controller/Index/Webhook.php
@@ -60,21 +60,29 @@ class Webhook extends \Magento\Framework\App\Action\Action implements CsrfAwareA
 
             $this->logger->debug('#webhook', array('trx_id' => $json->transaction->id, 'status' => $charge->status));        
 
-            if (isset($json->type) && $json->type == 'charge.succeeded' && $charge->status == 'completed' && ($json->transaction->method == 'store' || $json->transaction->method == 'bank_account')) {
+            if (isset($json->type) && ($json->transaction->method == 'store' || $json->transaction->method == 'bank_account')) {
                 $order = $this->_objectManager->create('Magento\Sales\Model\Order');            
                 $order->loadByAttribute('ext_order_id', $charge->id);
 
-                $status = \Magento\Sales\Model\Order::STATE_PROCESSING;
-                $order->setState($status)->setStatus($status);
-                $order->setTotalPaid($charge->amount);  
-                $order->addStatusHistoryComment("Pago recibido exitosamente")->setIsCustomerNotified(true);            
-                $order->save();
+                if($json->type == 'charge.succeeded' && $charge->status == 'completed'){
+                    $status = \Magento\Sales\Model\Order::STATE_PROCESSING;
+                    $order->setState($status)->setStatus($status);
+                    $order->setTotalPaid($charge->amount);  
+                    $order->addStatusHistoryComment("Pago recibido exitosamente")->setIsCustomerNotified(true);            
+                    $order->save();
 
-                $invoice = $this->invoiceService->prepareInvoice($order);        
-                $invoice->setTransactionId($charge->id);
-                $invoice->setRequestedCaptureCase(\Magento\Sales\Model\Order\Invoice::CAPTURE_ONLINE);
-                $invoice->register();
-                $invoice->save();
+                    $invoice = $this->invoiceService->prepareInvoice($order);        
+                    $invoice->setTransactionId($charge->id);
+                    $invoice->setRequestedCaptureCase(\Magento\Sales\Model\Order\Invoice::CAPTURE_ONLINE);
+                    $invoice->register();
+                    $invoice->save();
+                    
+                }else if($json->type == 'transaction.expired' && $charge->status == 'cancelled'){
+                    $status = \Magento\Sales\Model\Order::STATE_CANCELED;
+                    $order->setState($status)->setStatus($status);
+                    $order->addStatusHistoryComment("Pago vencido")->setIsCustomerNotified(true);            
+                    $order->save();
+                }  
             }       
         } catch (\Exception $e) {
             $this->logger->error('#webhook', array('msg' => $e->getMessage()));                    

--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -51,7 +51,7 @@ class Payment extends \Magento\Payment\Model\Method\AbstractMethod
     protected $_inlineTranslation;
     protected $_directoryList;
     protected $_file;
-    protected $iva = 0;
+    protected $iva;
 
     /**
      * 
@@ -126,6 +126,7 @@ class Payment extends \Magento\Payment\Model\Method\AbstractMethod
         $this->live_merchant_id = $this->getConfigData('live_merchant_id');
         $this->live_sk = $this->getConfigData('live_sk');        
         $this->deadline = $this->country === 'MX' ? $this->getConfigData('deadline_hours') : null;
+        $this->iva = $this->country === 'CO' ? $this->getConfigData('iva') : 0;
 
         $this->merchant_id = $this->is_sandbox ? $this->sandbox_merchant_id : $this->live_merchant_id;
         $this->sk = $this->is_sandbox ? $this->sandbox_sk : $this->live_sk;
@@ -490,7 +491,9 @@ class Payment extends \Magento\Payment\Model\Method\AbstractMethod
      * @return boolean
      */
     public function validateAddress($billing) {
-        if ($billing->getStreetLine(1) && $billing->getCity() && $billing->getPostcode() && $billing->getRegion() && $billing->getCountryId()) {
+        if ($billing->getCountryId() === 'MX' && $billing->getStreetLine(1) && $billing->getCity() && $billing->getPostcode() && $billing->getRegion()) {
+            return true;
+        }else if ($billing->getCountryId() === 'CO' && $billing->getStreetLine(1) && $billing->getCity() && $billing->getRegion()) {
             return true;
         }
         return false;
@@ -517,7 +520,8 @@ class Payment extends \Magento\Payment\Model\Method\AbstractMethod
                 'spei.received',
                 'chargeback.created',
                 'chargeback.rejected',
-                'chargeback.accepted'
+                'chargeback.accepted',
+                'transaction.expired'
             )
         );
 


### PR DESCRIPTION
Fix para guardar correctamente la dirección del cliente para Colombia.
Actualización de notificaciones para pagos vencidos, por medio del webhook configurado.