### PR TITLE
Actualización del Plugin Banks

### DIFF
--- a/Controller/Index/Webhook.php
+++ b/Controller/Index/Webhook.php
@@ -88,7 +88,12 @@ class Webhook extends \Magento\Framework\App\Action\Action implements CsrfAwareA
                     $order->setState($status)->setStatus($status);
                     $order->addStatusHistoryComment("Pago vencido")->setIsCustomerNotified(true);            
                     $order->save();
-                }  
+                }else if($json->type == 'charge.failed' && $charge->status == 'failed'){
+                    $status = \Magento\Sales\Model\Order::STATE_CANCELED;
+                    $order->setState($status)->setStatus($status);
+                    $order->addStatusHistoryComment("Pago Cancelado")->setIsCustomerNotified(true);            
+                    $order->save();
+                } 
             }       
         } catch (\Exception $e) {
             $this->logger->error('#webhook', array('msg' => $e->getMessage()));                    

--- a/Controller/Pse/Confirm.php
+++ b/Controller/Pse/Confirm.php
@@ -89,47 +89,50 @@ class Confirm extends \Magento\Framework\App\Action\Action
             }
             
             $this->logger->debug('#PSE', array('id' => $this->request->getParam('id'), 'status' => $charge->status));
-            if ($order && $charge->status != 'completed') {
-                $order->cancel();
-                $order->addStatusToHistory(\Magento\Sales\Model\Order::STATE_CANCELED, __('Autenticación de 3D Secure fallida.'));
-                $order->save();
-                $this->logger->debug('#PSE', array('msg' => 'Pago vía PSE fallido'));
-                                
-                return $this->resultPageFactory->create();        
-            }
-            
-            $status = \Magento\Sales\Model\Order::STATE_PROCESSING;            
-            $order->setExtOrderId($this->request->getParam('id')); // Registra el ID de la transacción de Openpay
-            $order->setState($status)->setStatus($status);
-            $order->setTotalPaid($charge->amount);  
-            $order->addStatusHistoryComment("Pago recibido exitosamente")->setIsCustomerNotified(true);            
-            $order->save();        
-            $requiresInvoice = true;
-            /** @var InvoiceCollection $invoiceCollection */
-            $invoiceCollection = $order->getInvoiceCollection();
-            if ( $invoiceCollection->count() > 0 ) {
-                /** @var Invoice $invoice */
-                foreach ($invoiceCollection as $invoice ) {
-                    if ( $invoice->getState() == Invoice::STATE_OPEN) {
-                        $invoice->setState(Invoice::STATE_PAID);
-                        $invoice->setTransactionId($charge->id);
-                        $invoice->pay()->save();
-                        $requiresInvoice = false;
-                        break;
+
+            if($order){
+                if ($charge->status == 'completed') {
+                    $status = \Magento\Sales\Model\Order::STATE_PROCESSING;            
+                    $order->setExtOrderId($this->request->getParam('id')); // Registra el ID de la transacción de Openpay
+                    $order->setState($status)->setStatus($status);
+                    $order->setTotalPaid($charge->amount);  
+                    $order->addStatusHistoryComment("Pago recibido exitosamente")->setIsCustomerNotified(true);            
+                    $order->save();        
+                    $requiresInvoice = true;
+                    /** @var InvoiceCollection $invoiceCollection */
+                    $invoiceCollection = $order->getInvoiceCollection();
+                    if ( $invoiceCollection->count() > 0 ) {
+                        /** @var Invoice $invoice */
+                        foreach ($invoiceCollection as $invoice ) {
+                            if ( $invoice->getState() == Invoice::STATE_OPEN) {
+                                $invoice->setState(Invoice::STATE_PAID);
+                                $invoice->setTransactionId($charge->id);
+                                $invoice->pay()->save();
+                                $requiresInvoice = false;
+                                break;
+                            }
+                        }
                     }
+                    if ( $requiresInvoice ) {
+                        $invoice = $this->_invoiceService->prepareInvoice($order);
+                        $invoice->setTransactionId($charge->id);
+                        // $invoice->setRequestedCaptureCase(\Magento\Sales\Model\Order\Invoice::CAPTURE_ONLINE);
+                        // $invoice->register();
+                        $invoice->pay()->save();
+                    }
+                    $payment = $order->getPayment();                                
+                    $payment->setAmountPaid($charge->amount);
+                    $payment->setIsTransactionPending(false);
+                    $payment->save();      
+                }else if($charge->status == 'cancelled' || $charge->status == 'failed'){
+                    $order->cancel();
+                    $order->addStatusToHistory(\Magento\Sales\Model\Order::STATE_CANCELED, __('Pago vía PSE fallido'));
+                    $order->save();
+                    $this->logger->debug('#PSE', array('msg' => 'Pago vía PSE fallido'));
+                                    
+                    return $this->resultPageFactory->create();   
                 }
             }
-            if ( $requiresInvoice ) {
-                $invoice = $this->_invoiceService->prepareInvoice($order);
-                $invoice->setTransactionId($charge->id);
-//            $invoice->setRequestedCaptureCase(\Magento\Sales\Model\Order\Invoice::CAPTURE_ONLINE);
-//            $invoice->register();
-                $invoice->pay()->save();
-            }
-            $payment = $order->getPayment();                                
-            $payment->setAmountPaid($charge->amount);
-            $payment->setIsTransactionPending(false);
-            $payment->save();
             
             $this->logger->debug('#PSE', array('redirect' => 'checkout/onepage/success'));
             return $this->resultRedirectFactory->create()->setPath('checkout/onepage/success');

--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -163,6 +163,7 @@ class Payment extends \Magento\Payment\Model\Method\AbstractMethod
         try {
 
             $customer_data = array(
+                'requires_account' => false,
                 'name' => $billing->getFirstname(),
                 'last_name' => $billing->getLastname(),
                 'phone_number' => $billing->getTelephone(),
@@ -515,10 +516,10 @@ class Payment extends \Magento\Payment\Model\Method\AbstractMethod
      * @return mixed
      */
     public function createWebhook() {
-        $protocol = $this->hostSecure() === true ? 'https://' : 'http://';
-        $uri = $_SERVER['HTTP_HOST']."/openpay/index/webhook";
+        $base_url = $this->_storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_WEB);
+        $uri = $base_url."openpay/index/webhook";
         $webhook_data = array(
-            'url' => $protocol.$uri,
+            'url' => $uri,
             'event_types' => array(
                 'verification',
                 'charge.succeeded',

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Openpay-Magento2-Banks
 
-Módulo para pagos vía SPEI con Openpay para Magento2 (soporte hasta v2.3.0)
+Módulo para pagos vía SPEI con Openpay para Magento2 (soporte hasta v2.3.5)
 
 
 ## Instalación


### PR DESCRIPTION
Fix Creación de Webhook con url correcta
Se envía parámetro requires_account=false al crear un cliente.
Se agrega evento para recibir notificaciones de pagos Fallidos.